### PR TITLE
eas.json: build Android using latest image

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -17,7 +17,10 @@
     },
     "production": {
       "channel": "production",
-      "autoIncrement": true
+      "autoIncrement": true,
+      "android": {
+        "image": "latest"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
When EAS builds for Android, the latest image can be used as we don't depend on a specific image version. This applies to the production profile, for which a build is automatically kicked off when commits are merged to the main branch.