### PR TITLE
BackHeader: fix back arrow color

### DIFF
--- a/components/Headers.js
+++ b/components/Headers.js
@@ -26,7 +26,7 @@ export function BackHeader({ children, title, subtitle, backgroundColor, color, 
                             style={styles.circleButton}
                             android_ripple={{ color: colorTheme.surfaceContainerHighest }}
                             onPress={() => { router.back() }}>
-                            <Ionicons name={Platform.OS === 'android' ? "arrow-back" : "chevron-back"} size={24} color={color} />
+                            <Ionicons name={Platform.OS === 'android' ? "arrow-back" : "chevron-back"} size={24} color={color ? color : colorTheme.onPrimaryContainer} />
                         </Pressable>
                     </View>
                     <Text style={[styles.title, { color: color ? color : colorTheme.onPrimaryContainer }]}>{title}</Text>


### PR DESCRIPTION
This commit fixes an issue where the back arrow would not be colored if a color was not provided. The back arrow now uses the same color, onPrimaryContainer, same as the other UI elements.